### PR TITLE
add location query parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This project is based on the WS4000+ project by Matt Walsh, which you can find [
 
 I've also added an in-memory caching system for images, since the ws4kp image preloading doesn't really work when running for hours or days at a time. The cache provides immediate access to frequently used images during app loops and relies on browser caching for persistence. For debugging you can enable monitoring and a basic set of tests with `window.cacheMonitor()`.
 
+## Usage
+
+By default, the application will request your location via the browser's geolocation API. You can also specify a location by adding `lat` and `lon` query parameters to the URL (e.g., `?lat=40.7128&lon=-74.0060`). Note that weather data is only available for locations where the NOAA API is available.
+
 ## Acknowledgments
 
 This project was initially forked from [WS4000+ (ws4kp)](https://github.com/netbymatt/ws4kp) by Matt Walsh. While this version has been significantly restructured and simplified, it relies heavily on the original graphics and visual assets created by Michael Battaglia. This fork primarily simplifies the code, including removing the complex build system and mess of dependencies, adds image caching, and adds some more screens. It also removed most of the configurability of Matt Walsh's version.

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -47,9 +47,64 @@ const init = () => {
   document.addEventListener('keydown', documentKeydown);
   postMessage('navButton', 'play');
   initImagePreloader();
-  autoGeolocate();
+  initLocationHandling();
   window.addEventListener('beforeunload', cleanup);
   document.addEventListener('visibilitychange', handleVisibilityChange);
+};
+
+const parseLocationFromQuery = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const lat = urlParams.get('lat');
+  const lon = urlParams.get('lon');
+  
+  if (!lat || !lon) {
+    if (lat && !lon) {
+      console.error('Missing longitude parameter (lon) - both lat and lon are required');
+    } else if (!lat && lon) {
+      console.error('Missing latitude parameter (lat) - both lat and lon are required');
+    }
+    return null;
+  }
+  
+  const latitude = parseFloat(lat);
+  const longitude = parseFloat(lon);
+  
+  // validate coordinates with detailed error logging
+  if (isNaN(latitude)) {
+    console.error(`Invalid latitude parameter: "${lat}" is not a valid number`);
+    return null;
+  }
+  
+  if (isNaN(longitude)) {
+    console.error(`Invalid longitude parameter: "${lon}" is not a valid number`);
+    return null;
+  }
+  
+  if (latitude < -90 || latitude > 90) {
+    console.error(`Invalid latitude parameter: ${latitude} is out of range (must be between -90 and 90)`);
+    return null;
+  }
+  
+  if (longitude < -180 || longitude > 180) {
+    console.error(`Invalid longitude parameter: ${longitude} is out of range (must be between -180 and 180)`);
+    return null;
+  }
+  
+  return { latitude, longitude };
+};
+
+const initLocationHandling = async () => {
+  // check for lat/lon query parameters first
+  const queryLocation = parseLocationFromQuery();
+  
+  if (queryLocation) {
+    console.log(`Using location from query params: ${queryLocation.latitude}, ${queryLocation.longitude}`);
+    getForecastFromLatLon(queryLocation.latitude, queryLocation.longitude, true);
+    return;
+  }
+  
+  // fall back to automatic geolocation
+  autoGeolocate();
 };
 
 const autoGeolocate = async () => {
@@ -282,9 +337,15 @@ const getPosition = async () =>
 
 const getForecastFromLatLon = (latitude, longitude) => {
   doRedirectToGeometry({ y: latitude, x: longitude }, point => {
-    const location = point.properties.relativeLocation.properties;
-    // Update the display with location name
-    console.log(`Location: ${location.city}, ${location.state}`);
+    // check if location data is available (NOAA API only covers US territories)
+    if (point.properties && point.properties.relativeLocation && point.properties.relativeLocation.properties) {
+      const location = point.properties.relativeLocation.properties;
+      // update the display with location name
+      console.log(`Location: ${location.city}, ${location.state}`);
+    } else {
+      // log coordinates for non-US locations
+      console.log(`Location: ${latitude.toFixed(4)}, ${longitude.toFixed(4)} (outside US coverage area)`);
+    }
   });
 };
 

--- a/weatherstar/js/modules/navigation.js
+++ b/weatherstar/js/modules/navigation.js
@@ -41,6 +41,13 @@ const getWeather = async (latLon, haveDataCallback) => {
       haveDataCallback(point);
     }
 
+    // check if location is supported (NOAA API only covers US territories)
+    if (!point.properties || !point.properties.relativeLocation) {
+      const error = new Error('LOCATION_NOT_SUPPORTED');
+      error.coordinates = { lat: latLon.lat, lon: latLon.lon };
+      throw error;
+    }
+
     // get stations
     const stations = await fetchAsync(point.properties.observationStations, 'json');
 
@@ -91,7 +98,12 @@ const getWeather = async (latLon, haveDataCallback) => {
     if (loadingDiv) {
       const instructionsDiv = loadingDiv.querySelector('.instructions');
       if (instructionsDiv) {
-        instructionsDiv.textContent = `Error loading weather data: ${error.message}`;
+        if (error.message === 'LOCATION_NOT_SUPPORTED' && error.coordinates) {
+          const { lat, lon } = error.coordinates;
+          instructionsDiv.textContent = `Weather data is not available for this location (${lat.toFixed(4)}, ${lon.toFixed(4)}).`;
+        } else {
+          instructionsDiv.textContent = `Error loading weather data: ${error.message}`;
+        }
       }
     }
   }


### PR DESCRIPTION
adds support for setting location via URL query parameters

## Features
- allows specifying location with `?lat=<latitude>&lon=<longitude>` query parameters
- validates coordinate ranges (lat: -90 to 90, lon: -180 to 180)
- falls back to geolocation API if parameters are missing or invalid
- provides clear error messages for invalid coordinates
- shows user-friendly messages for locations outside NOAA API coverage

## Changes
- **index.js**: added `parseLocationFromQuery()` and `initLocationHandling()` functions
- **navigation.js**: enhanced error handling for unsupported locations
- **README.md**: documented the new feature in usage section

## Usage Examples
- `?lat=40.7128&lon=-74.0060` (NYC)
- `?lat=34.0522&lon=-118.2437` (LA)
- invalid coordinates show helpful error messages

the feature is fully backward compatible and maintains existing geolocation behavior when no query parameters are provided.