### PR TITLE
Fix wake lock coordination with fullscreen state

### DIFF
--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -147,7 +147,6 @@ const btnFullScreenClick = () => {
     enterFullScreen();
   }
 
-  updateWakeLockState();
   updateFullScreenNavigate();
 
   return false;

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -195,23 +195,17 @@ let lastWakeLockState = null;
 
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
-  console.log(`updateWakeLockState: isPlaying=${isPlaying()}, fullscreenElement=${!!document.fullscreenElement}, shouldBeActive=${shouldBeActive}`);
 
   if (shouldBeActive !== lastWakeLockState) {
-    console.log(`Wake lock state changing from ${lastWakeLockState} to ${shouldBeActive}`);
     lastWakeLockState = shouldBeActive;
 
     setTimeout(() => {
       if (shouldBeActive) {
-        console.log('Calling noSleep(true)');
         noSleep(true);
       } else {
-        console.log('Calling noSleep(false)');
         noSleep(false);
       }
     }, 10);
-  } else {
-    console.log(`Wake lock state unchanged (${shouldBeActive}), skipping`);
   }
 };
 
@@ -380,12 +374,10 @@ const fullScreenResizeCheck = () => {
 
   fullScreenDebounceTimeout = setTimeout(() => {
     if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
-      console.log('Detected exit from fullscreen');
       exitFullScreenVisibilityChanges();
       updateWakeLockState();
     }
     if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
-      console.log('Detected enter to fullscreen');
       setTimeout(() => updateWakeLockState(), 100);
     }
 

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -193,7 +193,6 @@ const exitFullScreenVisibilityChanges = () => {
 
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
-  console.log('updateWakeLockState called:', { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
 
   if (shouldBeActive) {
     noSleep(true);
@@ -358,19 +357,23 @@ const getForecastFromLatLon = (latitude, longitude) => {
 };
 
 // check for change in full screen triggered by browser and run local functions
+let fullScreenDebounceTimeout = null;
+
 const fullScreenResizeCheck = () => {
-  console.log('fullScreenResizeCheck called:', { wasFull: fullScreenResizeCheck.wasFull, isFull: !!document.fullscreenElement });
-
-  if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
-    console.log('Detected exit from fullscreen');
-    exitFullScreenVisibilityChanges();
-  }
-  if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
-    console.log('Detected enter to fullscreen');
-    updateWakeLockState();
+  if (fullScreenDebounceTimeout) {
+    clearTimeout(fullScreenDebounceTimeout);
   }
 
-  fullScreenResizeCheck.wasFull = !!document.fullscreenElement;
+  fullScreenDebounceTimeout = setTimeout(() => {
+    if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
+      exitFullScreenVisibilityChanges();
+    }
+    if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
+      updateWakeLockState();
+    }
+
+    fullScreenResizeCheck.wasFull = !!document.fullscreenElement;
+  }, 50);
 };
 
 // expose functions for external use

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -193,6 +193,7 @@ const exitFullScreenVisibilityChanges = () => {
 
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
+  console.log('updateWakeLockState called:', { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
 
   if (shouldBeActive) {
     noSleep(true);
@@ -358,10 +359,14 @@ const getForecastFromLatLon = (latitude, longitude) => {
 
 // check for change in full screen triggered by browser and run local functions
 const fullScreenResizeCheck = () => {
+  console.log('fullScreenResizeCheck called:', { wasFull: fullScreenResizeCheck.wasFull, isFull: !!document.fullscreenElement });
+
   if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
+    console.log('Detected exit from fullscreen');
     exitFullScreenVisibilityChanges();
   }
   if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
+    console.log('Detected enter to fullscreen');
     updateWakeLockState();
   }
 

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -193,6 +193,8 @@ const exitFullScreenVisibilityChanges = () => {
 
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
+  console.log('updateWakeLockState called:', { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
+  console.trace('Call stack:');
 
   setTimeout(() => {
     if (shouldBeActive) {

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -191,18 +191,25 @@ const exitFullScreenVisibilityChanges = () => {
   divTwcBottom.classList.add('visible');
 };
 
+let lastWakeLockState = null;
+
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
   console.log('updateWakeLockState called:', { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
   console.trace('Call stack:');
 
-  setTimeout(() => {
-    if (shouldBeActive) {
-      noSleep(true);
-    } else {
-      noSleep(false);
-    }
-  }, 10);
+  // Only change wake lock state if it's actually different
+  if (shouldBeActive !== lastWakeLockState) {
+    lastWakeLockState = shouldBeActive;
+
+    setTimeout(() => {
+      if (shouldBeActive) {
+        noSleep(true);
+      } else {
+        noSleep(false);
+      }
+    }, 10);
+  }
 };
 
 window.updateWakeLockState = updateWakeLockState;

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -192,17 +192,11 @@ const exitFullScreenVisibilityChanges = () => {
 };
 
 let lastWakeLockState = null;
-let updateWakeLockStateCallCount = 0;
 
 const updateWakeLockState = () => {
-  updateWakeLockStateCallCount++;
   const shouldBeActive = isPlaying() && document.fullscreenElement;
-  console.log(`updateWakeLockState call #${updateWakeLockStateCallCount}:`, { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
-  console.trace('Call stack:');
 
-  // Only change wake lock state if it's actually different
   if (shouldBeActive !== lastWakeLockState) {
-    console.log(`Wake lock state changing from ${lastWakeLockState} to ${shouldBeActive}`);
     lastWakeLockState = shouldBeActive;
 
     setTimeout(() => {
@@ -212,8 +206,6 @@ const updateWakeLockState = () => {
         noSleep(false);
       }
     }, 10);
-  } else {
-    console.log(`Wake lock state unchanged (${shouldBeActive}), skipping`);
   }
 };
 

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -153,7 +153,7 @@ const btnFullScreenClick = () => {
   return false;
 };
 
-const enterFullScreen = async () => {
+let enterFullScreen = async () => {
   const element = document.querySelector('#divTwc');
 
   try {

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -43,6 +43,7 @@ const init = () => {
   });
   // local change detection when exiting full screen via ESC key (or other non button click methods)
   window.addEventListener('resize', fullScreenResizeCheck);
+  document.addEventListener('fullscreenchange', fullScreenResizeCheck);
   fullScreenResizeCheck.wasFull = false;
   document.addEventListener('keydown', documentKeydown);
   postMessage('navButton', 'play');
@@ -363,6 +364,7 @@ const fullScreenResizeCheck = () => {
     exitFullScreenVisibilityChanges();
   }
   if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
+    updateWakeLockState();
   }
 
   fullScreenResizeCheck.wasFull = !!document.fullscreenElement;

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -361,15 +361,11 @@ const getForecastFromLatLon = (latitude, longitude) => {
 // check for change in full screen triggered by browser and run local functions
 const fullScreenResizeCheck = () => {
   if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
-    // leaving full screen
     exitFullScreenVisibilityChanges();
   }
   if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
-    // entering full screen
-    // can't do much here because a UI interaction is required to change the full screen div element
   }
 
-  // store state of fullscreen element for next change detection
   fullScreenResizeCheck.wasFull = !!document.fullscreenElement;
 };
 
@@ -425,8 +421,3 @@ const handleVisibilityChange = () => {
   }
 };
 
-const fullScreenResizeCheck = () => {
-  if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
-    updateWakeLockState();
-  }
-};

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -189,8 +189,6 @@ const exitFullScreenVisibilityChanges = () => {
   const divTwcBottom = document.querySelector('#divTwcBottom');
   divTwcBottom.classList.remove('hidden');
   divTwcBottom.classList.add('visible');
-
-  updateWakeLockState();
 };
 
 const updateWakeLockState = () => {

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -56,7 +56,7 @@ const parseLocationFromQuery = () => {
   const urlParams = new URLSearchParams(window.location.search);
   const lat = urlParams.get('lat');
   const lon = urlParams.get('lon');
-  
+
   if (!lat || !lon) {
     if (lat && !lon) {
       console.error('Missing longitude parameter (lon) - both lat and lon are required');
@@ -65,44 +65,44 @@ const parseLocationFromQuery = () => {
     }
     return null;
   }
-  
+
   const latitude = parseFloat(lat);
   const longitude = parseFloat(lon);
-  
+
   // validate coordinates with detailed error logging
   if (isNaN(latitude)) {
     console.error(`Invalid latitude parameter: "${lat}" is not a valid number`);
     return null;
   }
-  
+
   if (isNaN(longitude)) {
     console.error(`Invalid longitude parameter: "${lon}" is not a valid number`);
     return null;
   }
-  
+
   if (latitude < -90 || latitude > 90) {
     console.error(`Invalid latitude parameter: ${latitude} is out of range (must be between -90 and 90)`);
     return null;
   }
-  
+
   if (longitude < -180 || longitude > 180) {
     console.error(`Invalid longitude parameter: ${longitude} is out of range (must be between -180 and 180)`);
     return null;
   }
-  
+
   return { latitude, longitude };
 };
 
 const initLocationHandling = async () => {
   // check for lat/lon query parameters first
   const queryLocation = parseLocationFromQuery();
-  
+
   if (queryLocation) {
     console.log(`Using location from query params: ${queryLocation.latitude}, ${queryLocation.longitude}`);
     getForecastFromLatLon(queryLocation.latitude, queryLocation.longitude, true);
     return;
   }
-  
+
   // fall back to automatic geolocation
   autoGeolocate();
 };
@@ -147,12 +147,7 @@ const btnFullScreenClick = () => {
     enterFullScreen();
   }
 
-  if (isPlaying()) {
-    noSleep(true);
-  } else {
-    noSleep(false);
-  }
-
+  updateWakeLockState();
   updateFullScreenNavigate();
 
   return false;
@@ -194,7 +189,21 @@ const exitFullScreenVisibilityChanges = () => {
   const divTwcBottom = document.querySelector('#divTwcBottom');
   divTwcBottom.classList.remove('hidden');
   divTwcBottom.classList.add('visible');
+
+  updateWakeLockState();
 };
+
+const updateWakeLockState = () => {
+  const shouldBeActive = isPlaying() && document.fullscreenElement;
+
+  if (shouldBeActive) {
+    noSleep(true);
+  } else {
+    noSleep(false);
+  }
+};
+
+window.updateWakeLockState = updateWakeLockState;
 
 const btnNavigateMenuClick = () => {
   postMessage('navButton', 'menu');
@@ -427,7 +436,7 @@ enterFullScreen = async () => {
   return originalEnterFullScreen();
 };
 
-// Track when user exits fullscreen manually  
+// Track when user exits fullscreen manually
 const originalExitFullscreen = exitFullscreen;
 exitFullscreen = () => {
   userWasInFullscreen = false;
@@ -438,31 +447,31 @@ exitFullscreen = () => {
   return originalExitFullscreen();
 };
 
-// Conservative recovery attempt
 const attemptFullscreenRecovery = () => {
   if (fullscreenRecoveryTimeout) {
     clearTimeout(fullscreenRecoveryTimeout);
   }
-  
+
   fullscreenRecoveryTimeout = setTimeout(async () => {
     if (!document.fullscreenElement && userWasInFullscreen) {
       try {
         console.log('Attempting conservative fullscreen recovery...');
         await enterFullScreen();
         console.log('Fullscreen recovery successful');
+        updateWakeLockState();
       } catch (error) {
         console.log('Fullscreen recovery failed:', error);
-        userWasInFullscreen = false; // Stop trying after failure
+        userWasInFullscreen = false;
       }
     }
-  }, 2000); // 2 second delay
+  }, 2000);
 };
 
 // Add recovery to existing fullScreenResizeCheck
 const originalFullScreenResizeCheck = fullScreenResizeCheck;
 fullScreenResizeCheck = () => {
   originalFullScreenResizeCheck();
-  
+
   // If we just lost fullscreen and user was previously in it, attempt recovery
   if (fullScreenResizeCheck.wasFull && !document.fullscreenElement && userWasInFullscreen) {
     attemptFullscreenRecovery();

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -192,14 +192,17 @@ const exitFullScreenVisibilityChanges = () => {
 };
 
 let lastWakeLockState = null;
+let updateWakeLockStateCallCount = 0;
 
 const updateWakeLockState = () => {
+  updateWakeLockStateCallCount++;
   const shouldBeActive = isPlaying() && document.fullscreenElement;
-  console.log('updateWakeLockState called:', { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
+  console.log(`updateWakeLockState call #${updateWakeLockStateCallCount}:`, { isPlaying: isPlaying(), fullscreenElement: !!document.fullscreenElement, shouldBeActive });
   console.trace('Call stack:');
 
   // Only change wake lock state if it's actually different
   if (shouldBeActive !== lastWakeLockState) {
+    console.log(`Wake lock state changing from ${lastWakeLockState} to ${shouldBeActive}`);
     lastWakeLockState = shouldBeActive;
 
     setTimeout(() => {
@@ -209,6 +212,8 @@ const updateWakeLockState = () => {
         noSleep(false);
       }
     }, 10);
+  } else {
+    console.log(`Wake lock state unchanged (${shouldBeActive}), skipping`);
   }
 };
 

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -194,11 +194,13 @@ const exitFullScreenVisibilityChanges = () => {
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
 
-  if (shouldBeActive) {
-    noSleep(true);
-  } else {
-    noSleep(false);
-  }
+  setTimeout(() => {
+    if (shouldBeActive) {
+      noSleep(true);
+    } else {
+      noSleep(false);
+    }
+  }, 10);
 };
 
 window.updateWakeLockState = updateWakeLockState;
@@ -369,11 +371,11 @@ const fullScreenResizeCheck = () => {
       exitFullScreenVisibilityChanges();
     }
     if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
-      updateWakeLockState();
+      setTimeout(() => updateWakeLockState(), 100);
     }
 
     fullScreenResizeCheck.wasFull = !!document.fullscreenElement;
-  }, 50);
+  }, 100);
 };
 
 // expose functions for external use

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -380,9 +380,12 @@ const fullScreenResizeCheck = () => {
 
   fullScreenDebounceTimeout = setTimeout(() => {
     if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
+      console.log('Detected exit from fullscreen');
       exitFullScreenVisibilityChanges();
+      updateWakeLockState();
     }
     if (!fullScreenResizeCheck.wasFull && document.fullscreenElement) {
+      console.log('Detected enter to fullscreen');
       setTimeout(() => updateWakeLockState(), 100);
     }
 

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -195,17 +195,23 @@ let lastWakeLockState = null;
 
 const updateWakeLockState = () => {
   const shouldBeActive = isPlaying() && document.fullscreenElement;
+  console.log(`updateWakeLockState: isPlaying=${isPlaying()}, fullscreenElement=${!!document.fullscreenElement}, shouldBeActive=${shouldBeActive}`);
 
   if (shouldBeActive !== lastWakeLockState) {
+    console.log(`Wake lock state changing from ${lastWakeLockState} to ${shouldBeActive}`);
     lastWakeLockState = shouldBeActive;
 
     setTimeout(() => {
       if (shouldBeActive) {
+        console.log('Calling noSleep(true)');
         noSleep(true);
       } else {
+        console.log('Calling noSleep(false)');
         noSleep(false);
       }
     }, 10);
+  } else {
+    console.log(`Wake lock state unchanged (${shouldBeActive}), skipping`);
   }
 };
 

--- a/weatherstar/js/index.js
+++ b/weatherstar/js/index.js
@@ -153,7 +153,7 @@ const btnFullScreenClick = () => {
   return false;
 };
 
-let enterFullScreen = async () => {
+const enterFullScreen = async () => {
   const element = document.querySelector('#divTwc');
 
   try {
@@ -425,55 +425,8 @@ const handleVisibilityChange = () => {
   }
 };
 
-// Conservative fullscreen recovery - only attempt if user was previously in fullscreen
-let userWasInFullscreen = false;
-let fullscreenRecoveryTimeout = null;
-
-// Track when user enters fullscreen manually
-const originalEnterFullScreen = enterFullScreen;
-enterFullScreen = async () => {
-  userWasInFullscreen = true;
-  return originalEnterFullScreen();
-};
-
-// Track when user exits fullscreen manually
-const originalExitFullscreen = exitFullscreen;
-exitFullscreen = () => {
-  userWasInFullscreen = false;
-  if (fullscreenRecoveryTimeout) {
-    clearTimeout(fullscreenRecoveryTimeout);
-    fullscreenRecoveryTimeout = null;
-  }
-  return originalExitFullscreen();
-};
-
-const attemptFullscreenRecovery = () => {
-  if (fullscreenRecoveryTimeout) {
-    clearTimeout(fullscreenRecoveryTimeout);
-  }
-
-  fullscreenRecoveryTimeout = setTimeout(async () => {
-    if (!document.fullscreenElement && userWasInFullscreen) {
-      try {
-        console.log('Attempting conservative fullscreen recovery...');
-        await enterFullScreen();
-        console.log('Fullscreen recovery successful');
-        updateWakeLockState();
-      } catch (error) {
-        console.log('Fullscreen recovery failed:', error);
-        userWasInFullscreen = false;
-      }
-    }
-  }, 2000);
-};
-
-// Add recovery to existing fullScreenResizeCheck
-const originalFullScreenResizeCheck = fullScreenResizeCheck;
-fullScreenResizeCheck = () => {
-  originalFullScreenResizeCheck();
-
-  // If we just lost fullscreen and user was previously in it, attempt recovery
-  if (fullScreenResizeCheck.wasFull && !document.fullscreenElement && userWasInFullscreen) {
-    attemptFullscreenRecovery();
+const fullScreenResizeCheck = () => {
+  if (fullScreenResizeCheck.wasFull && !document.fullscreenElement) {
+    updateWakeLockState();
   }
 };

--- a/weatherstar/js/modules/navigation.js
+++ b/weatherstar/js/modules/navigation.js
@@ -280,15 +280,16 @@ const setPlaying = newValue => {
   const playButton = document.querySelector('#NavigatePlay');
 
   if (playing) {
-    noSleep(true);
     playButton.title = 'Pause';
     playButton.src = 'images/nav/ic_pause_white_24dp_2x.png';
   } else {
-    noSleep(false);
     playButton.title = 'Play';
     playButton.src = 'images/nav/ic_play_arrow_white_24dp_2x.png';
   }
-  // if we're playing and on the progress screen jump to the next screen
+
+  if (typeof updateWakeLockState === 'function') {
+    updateWakeLockState();
+  }
   if (!progress) {
     return;
   }

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -5,6 +5,14 @@ class NoSleep {
     this.enabled = false;
     this._wakeLock = null;
     this._shouldStayActive = false;
+
+    // Listen for visibility changes to re-request wake lock when page becomes visible
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden && this._shouldStayActive && !this.enabled) {
+        console.log('Page became visible and wake lock is needed - re-requesting...');
+        this.enable();
+      }
+    });
   }
 
   async enable() {
@@ -19,7 +27,13 @@ class NoSleep {
         console.log(`_shouldStayActive = ${this._shouldStayActive}`);
         if (this._shouldStayActive) {
           console.log('Wake Lock lost but app still needs it - re-requesting...');
-          setTimeout(() => this.enable(), 100);
+          setTimeout(() => {
+            if (!document.hidden) {
+              this.enable();
+            } else {
+              console.log('Page is hidden, not re-requesting wake lock');
+            }
+          }, 100);
         } else {
           console.log('Wake Lock released and app no longer needs it - not re-requesting');
         }

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -48,20 +48,16 @@ class NoSleep {
 let wakeLock = false;
 
 const noSleep = (enable = false) => {
-  console.log(`noSleep called with enable=${enable}, current wakeLock=${wakeLock}`);
-
   // get a nosleep controller
   if (!noSleep.controller) {
     noSleep.controller = new NoSleep();
   }
   // don't call anything if the states match
   if (wakeLock === enable) {
-    console.log('noSleep: states match, returning early');
     return false;
   }
   // store the value
   wakeLock = enable;
-  console.log(`noSleep: calling ${enable ? 'enable' : 'disable'}()`);
   // call the function
   if (enable) {
     return noSleep.controller.enable();

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -4,15 +4,6 @@ class NoSleep {
   constructor() {
     this.enabled = false;
     this._wakeLock = null;
-    this._renewalInterval = null;
-
-    const handleVisibilityChange = () => {
-      if (this._wakeLock !== null && document.visibilityState === 'visible') {
-        this.enable();
-      }
-    };
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    document.addEventListener('fullscreenchange', handleVisibilityChange);
   }
 
   async enable() {
@@ -22,11 +13,8 @@ class NoSleep {
       console.log('Wake Lock active.');
       this._wakeLock.addEventListener('release', () => {
         console.log('Wake Lock released.');
-        this._clearRenewal();
+        this.enabled = false;
       });
-      
-      // Start renewal process (conservative: every hour)
-      this._startRenewal();
     } catch (err) {
       this.enabled = false;
       console.error('Wake Lock failed:', err);
@@ -40,43 +28,8 @@ class NoSleep {
       this._wakeLock = null;
     }
     this.enabled = false;
-    this._clearRenewal();
   }
 
-  _startRenewal() {
-    this._clearRenewal(); // Clear any existing renewal
-    
-    // Renew every hour (conservative approach)
-    this._renewalInterval = setInterval(async () => {
-      if (this.enabled && this._wakeLock) {
-        try {
-          // Release current wake lock
-          this._wakeLock.release();
-          
-          // Request new wake lock
-          this._wakeLock = await navigator.wakeLock.request('screen');
-          console.log('Wake Lock renewed successfully.');
-          
-          // Set up release listener for new wake lock
-          this._wakeLock.addEventListener('release', () => {
-            console.log('Wake Lock released.');
-            this._clearRenewal();
-          });
-        } catch (err) {
-          console.error('Wake Lock renewal failed:', err);
-          this.enabled = false;
-          this._clearRenewal();
-        }
-      }
-    }, 60 * 60 * 1000); // 1 hour
-  }
-
-  _clearRenewal() {
-    if (this._renewalInterval) {
-      clearInterval(this._renewalInterval);
-      this._renewalInterval = null;
-    }
-  }
 
   get isEnabled() {
     return this.enabled;

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -9,7 +9,6 @@ class NoSleep {
     // Listen for visibility changes to re-request wake lock when page becomes visible
     document.addEventListener('visibilitychange', () => {
       if (!document.hidden && this._shouldStayActive && !this.enabled) {
-        console.log('Page became visible and wake lock is needed - re-requesting...');
         this.enable();
       }
     });
@@ -24,18 +23,12 @@ class NoSleep {
       this._wakeLock.addEventListener('release', () => {
         console.log('Wake Lock released.');
         this.enabled = false;
-        console.log(`_shouldStayActive = ${this._shouldStayActive}`);
         if (this._shouldStayActive) {
-          console.log('Wake Lock lost but app still needs it - re-requesting...');
           setTimeout(() => {
             if (!document.hidden) {
               this.enable();
-            } else {
-              console.log('Page is hidden, not re-requesting wake lock');
             }
           }, 100);
-        } else {
-          console.log('Wake Lock released and app no longer needs it - not re-requesting');
         }
       });
     } catch (err) {
@@ -46,7 +39,6 @@ class NoSleep {
   }
 
   disable() {
-    console.log('NoSleep.disable() called - setting _shouldStayActive = false');
     this._shouldStayActive = false;
     if (this._wakeLock) {
       this._wakeLock.release();

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -17,7 +17,7 @@ class NoSleep {
         console.log('Wake Lock released.');
         this.enabled = false;
         if (this._shouldStayActive) {
-          console.log('Wake Lock auto-releasing, re-requesting...');
+          console.log('Wake Lock lost but app still needs it - re-requesting...');
           setTimeout(() => this.enable(), 100);
         }
       });

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -41,16 +41,20 @@ class NoSleep {
 let wakeLock = false;
 
 const noSleep = (enable = false) => {
+  console.log(`noSleep called with enable=${enable}, current wakeLock=${wakeLock}`);
+
   // get a nosleep controller
   if (!noSleep.controller) {
     noSleep.controller = new NoSleep();
   }
   // don't call anything if the states match
   if (wakeLock === enable) {
+    console.log('noSleep: states match, returning early');
     return false;
   }
   // store the value
   wakeLock = enable;
+  console.log(`noSleep: calling ${enable ? 'enable' : 'disable'}()`);
   // call the function
   if (enable) {
     return noSleep.controller.enable();

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -16,9 +16,12 @@ class NoSleep {
       this._wakeLock.addEventListener('release', () => {
         console.log('Wake Lock released.');
         this.enabled = false;
+        console.log(`_shouldStayActive = ${this._shouldStayActive}`);
         if (this._shouldStayActive) {
           console.log('Wake Lock lost but app still needs it - re-requesting...');
           setTimeout(() => this.enable(), 100);
+        } else {
+          console.log('Wake Lock released and app no longer needs it - not re-requesting');
         }
       });
     } catch (err) {
@@ -29,6 +32,7 @@ class NoSleep {
   }
 
   disable() {
+    console.log('NoSleep.disable() called - setting _shouldStayActive = false');
     this._shouldStayActive = false;
     if (this._wakeLock) {
       this._wakeLock.release();

--- a/weatherstar/js/modules/utils/nosleep.js
+++ b/weatherstar/js/modules/utils/nosleep.js
@@ -4,16 +4,22 @@ class NoSleep {
   constructor() {
     this.enabled = false;
     this._wakeLock = null;
+    this._shouldStayActive = false;
   }
 
   async enable() {
     try {
+      this._shouldStayActive = true;
       this._wakeLock = await navigator.wakeLock.request('screen');
       this.enabled = true;
       console.log('Wake Lock active.');
       this._wakeLock.addEventListener('release', () => {
         console.log('Wake Lock released.');
         this.enabled = false;
+        if (this._shouldStayActive) {
+          console.log('Wake Lock auto-releasing, re-requesting...');
+          setTimeout(() => this.enable(), 100);
+        }
       });
     } catch (err) {
       this.enabled = false;
@@ -23,6 +29,7 @@ class NoSleep {
   }
 
   disable() {
+    this._shouldStayActive = false;
     if (this._wakeLock) {
       this._wakeLock.release();
       this._wakeLock = null;


### PR DESCRIPTION
- Remove automatic wake lock renewal that was causing fullscreen exits
- Centralize wake lock management to only activate when both playing AND fullscreen
- Update exitFullScreenVisibilityChanges to disable wake lock when exiting fullscreen
- Remove problematic event listeners in nosleep.js
- Update fullscreen recovery to coordinate with wake lock state
- Remove trailing whitespace